### PR TITLE
Harden device selection and guard MPS usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .git/*
 **/__pycache__/
-tests/
+tests/*
+!tests/test_device_selection.py
 .vscode/
 .cursor/
 benchmark/
@@ -16,6 +17,7 @@ README_*.md
 run_*.py
 vram_diagnostic.py
 test_*.py
+!tests/test_device_selection.py
 VRAM_OPTIMIZATIONS_SUMMARY.md
 seedvr2.py
 src/core/isolated_generation.py

--- a/__init__.py
+++ b/__init__.py
@@ -9,8 +9,21 @@ Migration en cours...
 """
 
 # 🆕 TENTATIVE: Nouvelle architecture modulaire
-from .src.interfaces.comfyui_node import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
-USING_MODULAR = True
+NODE_CLASS_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS = {}
+USING_MODULAR = False
+
+try:
+    from .src.interfaces.comfyui_node import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS  # type: ignore[assignment]
+except ImportError:  # pragma: no cover - fallback for direct package execution
+    try:
+        from src.interfaces.comfyui_node import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS  # type: ignore[assignment]
+    except ImportError:
+        USING_MODULAR = False
+    else:
+        USING_MODULAR = True
+else:
+    USING_MODULAR = True
 
 
 # Export pour ComfyUI

--- a/src/common/distributed/__init__.py
+++ b/src/common/distributed/__init__.py
@@ -23,6 +23,7 @@ from .basic import (
     get_global_rank,
     get_local_rank,
     get_world_size,
+    has_mps,
     init_torch,
 )
 
@@ -33,5 +34,6 @@ __all__ = [
     "get_global_rank",
     "get_local_rank",
     "get_world_size",
+    "has_mps",
     "init_torch",
 ]

--- a/src/data/image/transforms/area_resize.py
+++ b/src/data/image/transforms/area_resize.py
@@ -19,6 +19,7 @@ import torch
 from PIL import Image
 from torchvision.transforms import functional as TVF
 from torchvision.transforms.functional import InterpolationMode
+from src.common.distributed import has_mps
 
 
 class AreaResize:
@@ -31,7 +32,7 @@ class AreaResize:
         self.max_area = max_area
         self.downsample_only = downsample_only
         self.interpolation = interpolation
-        if torch.mps.is_available():
+        if has_mps():
             self.interpolation = InterpolationMode.BILINEAR
 
     def __call__(self, image: Union[torch.Tensor, Image.Image]):

--- a/src/data/image/transforms/na_resize.py
+++ b/src/data/image/transforms/na_resize.py
@@ -12,12 +12,13 @@
 # // See the License for the specific language governing permissions and
 # // limitations under the License.
 
-import torch
 from typing import Literal
+import torch
 from torchvision.transforms import CenterCrop, Compose, InterpolationMode, Resize
 
 from .area_resize import AreaResize
 from .side_resize import SideResize
+from src.common.distributed import has_mps
 
 def NaResize(
     resolution: int,
@@ -25,7 +26,7 @@ def NaResize(
     downsample_only: bool,
     interpolation: InterpolationMode = InterpolationMode.BICUBIC,
 ):
-    Interpolation = InterpolationMode.BILINEAR if torch.mps.is_available() else interpolation
+    Interpolation = InterpolationMode.BILINEAR if has_mps() else interpolation
     if mode == "area":
         return AreaResize(
             max_area=resolution**2,

--- a/src/data/image/transforms/side_resize.py
+++ b/src/data/image/transforms/side_resize.py
@@ -17,6 +17,7 @@ import torch
 from PIL import Image
 from torchvision.transforms import InterpolationMode
 from torchvision.transforms import functional as TVF
+from src.common.distributed import has_mps
 
 class SideResize:
     def __init__(
@@ -28,7 +29,7 @@ class SideResize:
         self.size = size
         self.downsample_only = downsample_only
         self.interpolation = interpolation
-        if torch.mps.is_available():
+        if has_mps():
             self.interpolation = InterpolationMode.BILINEAR
 
     def __call__(self, image: Union[torch.Tensor, Image.Image]):

--- a/src/optimization/blockswap.py
+++ b/src/optimization/blockswap.py
@@ -76,7 +76,7 @@ def apply_block_swap_to_dit(runner, block_swap_config: Dict[str, Any], debug) ->
         model = model.dit_model
     
     # Determine devices
-    device = str(get_device()) if (torch.cuda.is_available() or torch.mps.is_available()) else "cpu"
+    device = str(get_device())
     offload_device = "cpu"
 
     configs = []

--- a/src/optimization/compatibility.py
+++ b/src/optimization/compatibility.py
@@ -8,6 +8,8 @@ Extracted from: seedvr2.py (lines 1045-1630)
 import torch
 import types
 
+from src.common.distributed import has_mps
+
 def call_rope_with_stability(method, *args, **kwargs):
     """
     Call RoPE method with stability fixes:
@@ -50,7 +52,7 @@ class FP8CompatibleDiT(torch.nn.Module):
             self.debug.start_timer("_convert_rope_freqs")
             self._convert_rope_freqs()
             self.debug.end_timer("_convert_rope_freqs", "RoPE freqs conversion")
-            if torch.mps.is_available():
+            if has_mps():
                 self.debug.log(f"Also converting NaDiT parameters/buffers for MPS backend", category="setup", force=True)
                 self.debug.start_timer("_force_nadit_bfloat16")
                 self._force_nadit_bfloat16()
@@ -345,7 +347,7 @@ class FP8CompatibleDiT(torch.nn.Module):
             k = k.view(batch_size, seq_len, num_heads, head_dim).transpose(1, 2)
             v = v.view(batch_size, seq_len, num_heads, head_dim).transpose(1, 2)
             
-            if torch.mps.is_available():
+            if has_mps():
                 attn_output = torch.nn.functional.scaled_dot_product_attention(
                     q, k, v,
                     dropout_p=0.0,

--- a/src/utils/debug.py
+++ b/src/utils/debug.py
@@ -12,6 +12,7 @@ from typing import Optional, List, Dict, Any, Union
 from datetime import datetime
 from src.optimization.memory_manager import get_vram_usage, get_basic_vram_info, get_ram_usage, reset_vram_peak
 from contextlib import contextmanager
+from src.common.distributed import has_mps
 
 
 class Debug:
@@ -309,7 +310,7 @@ class Debug:
         }
         
         # VRAM metrics
-        if torch.cuda.is_available() or torch.mps.is_available():
+        if torch.cuda.is_available() or has_mps():
             metrics['vram_allocated'], metrics['vram_reserved'], current_global_peak = get_vram_usage(debug=self)
             
             # Calculate peak since last log_memory_state
@@ -322,7 +323,7 @@ class Debug:
                 metrics['vram_free'] = vram_info["free_gb"]
                 metrics['vram_total'] = vram_info["total_gb"]
                 
-                backend = "MPS" if torch.mps.is_available() else "VRAM"
+                backend = "MPS" if has_mps() else "VRAM"
                 metrics['summary_vram'] = (f"  [{backend}] {metrics['vram_allocated']:.2f}GB allocated / "
                         f"{metrics['vram_reserved']:.2f}GB reserved / "
                         f"Peak: {metrics['vram_peak_since_last']:.2f}GB / "
@@ -345,7 +346,7 @@ class Debug:
             metrics['summary_ram'] = ""
         
         # Update VRAM history for tracking
-        if torch.cuda.is_available() or torch.mps.is_available():
+        if torch.cuda.is_available() or has_mps():
             self.vram_history.append(metrics['vram_allocated'])
         
         return metrics

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -1,0 +1,23 @@
+import platform
+import sys
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.common.distributed.basic import get_device, has_mps
+
+
+def test_get_device_safe():
+    dev = get_device()
+    assert isinstance(dev, torch.device)
+
+
+def test_has_mps_safe():
+    flag = has_mps()
+    assert isinstance(flag, bool)
+    if platform.system() != "Darwin":
+        assert flag is False


### PR DESCRIPTION
## Summary
- implement platform-aware `get_device()` and new `has_mps()` helper, exporting them for reuse
- replace direct MPS probes and noisy messages across generation, transforms, memory management, and compatibility layers with guarded logic using the helpers
- add a smoke test covering the new helper behaviour and make the package init resilient to missing optional deps during testing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ce259f3c3c83259a2498cd0fa5f20e