### PR TITLE
Use device type when enabling torch.autocast

### DIFF
--- a/src/core/generation.py
+++ b/src/core/generation.py
@@ -242,7 +242,9 @@ def generation_step(runner, text_embeds_dict, preserve_vram, cond_latents, tempo
 
     # Use adaptive autocast for optimal performance
     with torch.no_grad():
-        with torch.autocast(str(get_device()), autocast_dtype, enabled=True):
+        dev = get_device()
+        # torch.autocast requires the device type string (e.g., 'cuda', 'cpu', 'mps').
+        with torch.autocast(dev.type, autocast_dtype, enabled=True):
             video_tensors = runner.inference(
                 noises=noises,
                 conditions=conditions,


### PR DESCRIPTION
## Summary
- update the generation autocast context to use the device type returned by `get_device`
- document why the autocast context needs `dev.type`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce30e00e008325b6c1ada71d453585