### PR TITLE
Add utilities for video metadata probing and chunk extraction

### DIFF
--- a/inference_cli.py
+++ b/inference_cli.py
@@ -937,7 +937,10 @@ def main():
 
         est_h, est_w = estimate_output_frame_shape(meta, args.resolution)
         est_bytes = est_h * est_w * 3 * 2 * chunk_size
-        print(f"[INFO] Estimated RAM per chunk ≈ {est_bytes / (1024 ** 2):.1f} MiB")
+        print(
+            f"[INFO] Approx. RAM per chunk (frame buffers only) ≈ {est_bytes / (1024 ** 2):.1f} MiB "
+            f"(excludes activations/overlap; fp16, {est_w}x{est_h}x3)"
+        )
 
         chunk_iter = extract_frame_chunks(
             args.video_path,
@@ -1006,7 +1009,7 @@ def main():
                 if chunk_index > 0 and overlap > 0 and prev_output_tail is not None:
                     seam = apply_temporal_overlap_blending(
                         prev_output_tail,
-                        args.batch_size,
+                        0,  # batch_size is unused in seam mode; pass 0 for clarity
                         overlap,
                         next_frames=result_chunk[:overlap],
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ diffusers>=v0.33.1
 pytorch-extension
 rotary_embedding_torch>=0.5.3
 opencv-python
+imageio>=2.28.0
 peft>=0.15.0


### PR DESCRIPTION
## Summary
- add `probe_video_meta` to capture fps, frame count, and dimensions via OpenCV before processing
- introduce an `extract_frame_chunks` generator that streams fp16-normalized frame tensors without a global stack
- surface probed metadata in the CLI with an optional chunk-extractor dry run and clarify the `--load_cap` help text

## Testing
- python -m compileall inference_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cee43c565c8325aaa93e3e3a58f6b0