### PR TITLE
Add attention window logging and overlay tooling

### DIFF
--- a/src/core/model_manager.py
+++ b/src/core/model_manager.py
@@ -39,7 +39,15 @@ from src.optimization.blockswap import apply_block_swap_to_dit
 script_directory = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-def configure_runner(model, base_cache_dir, preserve_vram=False, debug=False, block_swap_config=None, cached_runner=None):
+def configure_runner(
+    model,
+    base_cache_dir,
+    preserve_vram=False,
+    debug=False,
+    block_swap_config=None,
+    cached_runner=None,
+    log_window_info=False,
+):
     """
     Configure and create a VideoDiffusionInfer runner for the specified model
     
@@ -49,6 +57,7 @@ def configure_runner(model, base_cache_dir, preserve_vram=False, debug=False, bl
         preserve_vram (bool): Whether to preserve VRAM
         debug (bool): Enable debug logging
         block_swap_config (dict): Optional BlockSwap configuration
+        log_window_info (bool): Enable attention window logging instrumentation
         cached_runner: Optional cached runner to reuse entirely (not just DiT)
         
     Returns:
@@ -133,6 +142,9 @@ def configure_runner(model, base_cache_dir, preserve_vram=False, debug=False, bl
     # DiT model configuration is now handled directly in the YAML config files
     # No need for dynamic path resolution here anymore!
 
+    if log_window_info:
+        config.dit.model["log_window_info"] = bool(log_window_info)
+
     # Load and configure VAE with additional parameters
     vae_config_path = os.path.join(script_directory, 'src/models/video_vae_v3/s8_c16_t4_inflation_sd3.yaml')
     t = time.time()
@@ -159,6 +171,7 @@ def configure_runner(model, base_cache_dir, preserve_vram=False, debug=False, bl
     t = time.time()
     # Create runner
     runner = VideoDiffusionInfer(config, debug)
+    runner._log_window_info = bool(log_window_info)
     OmegaConf.set_readonly(runner.config, False)
     # Store model name for cache validation
     runner._model_name = model

--- a/src/models/dit/nadit.py
+++ b/src/models/dit/nadit.py
@@ -132,6 +132,9 @@ class NaDiT(nn.Module):
                 for i in range(num_layers)
             ]
         )
+        for idx, block in enumerate(self.blocks):
+            if hasattr(block, "set_layer_index"):
+                block.set_layer_index(idx, attention_variant="dit")
         self.vid_out = NaPatchOut(
             out_channels=vid_out_channels,
             patch_size=patch_size,

--- a/src/models/dit_v2/nablocks/attention/mmattn.py
+++ b/src/models/dit_v2/nablocks/attention/mmattn.py
@@ -13,6 +13,7 @@
 # // limitations under the License.
 
 from typing import Optional, Tuple, Union
+import math
 import torch
 from einops import rearrange
 from torch import nn
@@ -146,6 +147,7 @@ class NaSwinAttention(NaMMAttention):
         *args,
         window: Union[int, Tuple[int, int, int]],
         window_method: str,
+        log_window_info: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -154,6 +156,82 @@ class NaSwinAttention(NaMMAttention):
         assert all(map(lambda v: isinstance(v, int) and v >= 0, self.window))
 
         self.window_op = get_window_op(window_method)
+        self._log_window_info = bool(log_window_info)
+        self._did_log_banner = False
+        self._lattice_cache = []
+        self._layer_index = None
+        self._attention_variant = "dit_v2"
+
+    @staticmethod
+    def _compute_lattice(latent_shape, base_window, shifted=False):
+        t, h, w = latent_shape
+        base_nt, base_nh, base_nw = base_window
+        resized_nt = base_nt if base_nt else 1
+        resized_nh = base_nh if base_nh else 1
+        resized_nw = base_nw if base_nw else 1
+        safe_hw = max(h * w, 1)
+        scale = math.sqrt((45 * 80) / safe_hw)
+        resized_h = round(h * scale)
+        resized_w = round(w * scale)
+        wh = math.ceil(resized_h / resized_nh) if resized_nh else h
+        ww = math.ceil(resized_w / resized_nw) if resized_nw else w
+        wt = math.ceil(min(t, 30) / resized_nt) if resized_nt else max(t, 1)
+        wt = max(wt, 1)
+        wh = max(wh, 1)
+        ww = max(ww, 1)
+
+        if shifted:
+            st = 0.5 if wt < t else 0.0
+            sh = 0.5 if wh < h else 0.0
+            sw = 0.5 if ww < w else 0.0
+            nt = math.ceil((t - st) / wt) if wt else 0
+            nh = math.ceil((h - sh) / wh) if wh else 0
+            nw = math.ceil((w - sw) / ww) if ww else 0
+            nt = nt + 1 if st > 0 else 1
+            nh = nh + 1 if sh > 0 else 1
+            nw = nw + 1 if sw > 0 else 1
+        else:
+            nt = math.ceil(t / wt) if wt else 0
+            nh = math.ceil(h / wh) if wh else 0
+            nw = math.ceil(w / ww) if ww else 0
+
+        return (int(wt), int(wh), int(ww)), (int(nt), int(nh), int(nw))
+
+    def _maybe_log_lattice(self, vid_shape: torch.LongTensor):
+        if not self._log_window_info or self._did_log_banner:
+            return
+
+        latent_dims = tuple(int(x) for x in vid_shape[0].tolist())
+        regular_p, regular_n = self._compute_lattice(latent_dims, self.window, shifted=False)
+        shifted_p, shifted_n = self._compute_lattice(latent_dims, self.window, shifted=True)
+        module_label = f"{self.__class__.__name__}(layer={self._layer_index if self._layer_index is not None else 'NA'}, variant={self._attention_variant})"
+        latent_str = f"[{latent_dims[0]},{latent_dims[1]},{latent_dims[2]}]"
+        regular_p_str = f"[{regular_p[0]},{regular_p[1]},{regular_p[2]}]"
+        regular_n_str = f"[{regular_n[0]},{regular_n[1]},{regular_n[2]}]"
+        shifted_p_str = f"[{shifted_p[0]},{shifted_p[1]},{shifted_p[2]}]"
+        shifted_n_str = f"[{shifted_n[0]},{shifted_n[1]},{shifted_n[2]}]"
+        print(
+            f"[ATTN] ATTN_MODE=fixed latent={latent_str} "
+            f"regular p={regular_p_str} n={regular_n_str} "
+            f"shifted p={shifted_p_str} n={shifted_n_str} module={module_label}"
+        )
+        self._lattice_cache.append(
+            {
+                "latent": [int(x) for x in latent_dims],
+                "regular": {"p": [int(x) for x in regular_p], "n": [int(x) for x in regular_n]},
+                "shifted": {"p": [int(x) for x in shifted_p], "n": [int(x) for x in shifted_n]},
+                "module": module_label,
+            }
+        )
+        self._did_log_banner = True
+
+    def set_layer_index(self, layer_index: int, attention_variant: str = "dit_v2"):
+        self._layer_index = layer_index
+        self._attention_variant = attention_variant or self._attention_variant
+
+    def pop_window_lattice(self):
+        data, self._lattice_cache = self._lattice_cache, []
+        return data
 
     def forward(
         self,
@@ -183,6 +261,8 @@ class NaSwinAttention(NaMMAttention):
 
         # re-org the input seq for window attn
         cache_win = cache.namespace(f"{self.window_method}_{self.window}_sd3")
+
+        self._maybe_log_lattice(vid_shape)
 
         def make_window(x: torch.Tensor):
             t, h, w, _ = x.shape

--- a/src/models/dit_v2/nadit.py
+++ b/src/models/dit_v2/nadit.py
@@ -161,6 +161,9 @@ class NaDiT(nn.Module):
                 for i in range(num_layers)
             ]
         )
+        for idx, block in enumerate(self.blocks):
+            if hasattr(block, "set_layer_index"):
+                block.set_layer_index(idx, attention_variant="dit_v2")
 
         self.vid_out_norm = None
         if vid_out_norm is not None:

--- a/tools/overlay_windows.py
+++ b/tools/overlay_windows.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Overlay attention window boundaries onto an image."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+from PIL import Image, ImageDraw
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Draw attention window grids over an image.")
+    parser.add_argument("--image", required=True, help="Path to the generated image (PNG).")
+    parser.add_argument("--lattice", required=True, help="Path to the lattice JSON emitted by the CLI.")
+    parser.add_argument("--save", default=None, help="Destination path for the overlay image.")
+    parser.add_argument(
+        "--latent_downsample",
+        type=int,
+        default=8,
+        help="Spatial downsample factor between latent tokens and pixels (default: 8).",
+    )
+    return parser.parse_args()
+
+
+def _regular_boundaries(latent: Sequence[int], window_size: Sequence[int], counts: Sequence[int]) -> Tuple[List[int], List[int]]:
+    if len(latent) < 3 or len(window_size) < 3 or len(counts) < 3:
+        return [], []
+    _, h, w = (int(latent[0]), int(latent[1]), int(latent[2]))
+    _, wh, ww = (int(window_size[0]), int(window_size[1]), int(window_size[2]))
+    _, nh, nw = (int(counts[0]), int(counts[1]), int(counts[2]))
+
+    col_boundaries = {0, w}
+    row_boundaries = {0, h}
+
+    for iw in range(max(nw, 0)):
+        start = iw * ww
+        end = min((iw + 1) * ww, w)
+        col_boundaries.update({start, end})
+    for ih in range(max(nh, 0)):
+        start = ih * wh
+        end = min((ih + 1) * wh, h)
+        row_boundaries.update({start, end})
+    return sorted(col_boundaries), sorted(row_boundaries)
+
+
+def _shifted_boundaries(latent: Sequence[int], window_size: Sequence[int], counts: Sequence[int]) -> Tuple[List[int], List[int]]:
+    if len(latent) < 3 or len(window_size) < 3 or len(counts) < 3:
+        return [], []
+    t, h, w = (int(latent[0]), int(latent[1]), int(latent[2]))
+    wt, wh, ww = (int(window_size[0]), int(window_size[1]), int(window_size[2]))
+    nt, nh, nw = (int(counts[0]), int(counts[1]), int(counts[2]))
+
+    wt = max(wt, 1)
+    wh = max(wh, 1)
+    ww = max(ww, 1)
+
+    st = 0.5 if wt < t else 0.0
+    sh = 0.5 if wh < h else 0.0
+    sw = 0.5 if ww < w else 0.0
+
+    col_boundaries = {0, w}
+    row_boundaries = {0, h}
+
+    for iw in range(max(nw, 0)):
+        start = max(int((iw - sw) * ww), 0)
+        end = min(int((iw - sw + 1) * ww), w)
+        col_boundaries.update({start, end})
+    for ih in range(max(nh, 0)):
+        start = max(int((ih - sh) * wh), 0)
+        end = min(int((ih - sh + 1) * wh), h)
+        row_boundaries.update({start, end})
+    return sorted(col_boundaries), sorted(row_boundaries)
+
+
+def _to_pixels(values: Iterable[int], scale: int, limit: int) -> List[int]:
+    pixels = []
+    for value in values:
+        px = int(round(value * scale))
+        px = max(0, min(px, limit))
+        pixels.append(px)
+    return sorted(set(pixels))
+
+
+def _draw_dashed_line(draw: ImageDraw.ImageDraw, start: Tuple[int, int], end: Tuple[int, int], fill, width: int, dash: int = 12, gap: int = 8) -> None:
+    x1, y1 = start
+    x2, y2 = end
+    length = math.hypot(x2 - x1, y2 - y1)
+    if length == 0:
+        return
+    dx = (x2 - x1) / length
+    dy = (y2 - y1) / length
+    distance = 0.0
+    while distance < length:
+        segment_end = min(distance + dash, length)
+        sx1 = x1 + dx * distance
+        sy1 = y1 + dy * distance
+        sx2 = x1 + dx * segment_end
+        sy2 = y1 + dy * segment_end
+        draw.line((sx1, sy1, sx2, sy2), fill=fill, width=width)
+        distance += dash + gap
+
+
+def _accumulate_boundaries(lattice_entries: Sequence[dict]) -> Tuple[List[int], List[int], List[int], List[int]]:
+    regular_cols, regular_rows = set(), set()
+    shifted_cols, shifted_rows = set(), set()
+
+    for entry in lattice_entries:
+        latent = entry.get("latent")
+        regular = entry.get("regular", {})
+        shifted = entry.get("shifted", {})
+
+        cols, rows = _regular_boundaries(latent or [], regular.get("p", []), regular.get("n", []))
+        regular_cols.update(cols)
+        regular_rows.update(rows)
+
+        cols_shift, rows_shift = _shifted_boundaries(latent or [], shifted.get("p", []), shifted.get("n", []))
+        shifted_cols.update(cols_shift)
+        shifted_rows.update(rows_shift)
+
+    return (
+        sorted(regular_cols),
+        sorted(regular_rows),
+        sorted(shifted_cols),
+        sorted(shifted_rows),
+    )
+
+
+def main() -> None:
+    args = _parse_args()
+    image_path = Path(args.image)
+    lattice_path = Path(args.lattice)
+
+    if not image_path.exists():
+        raise FileNotFoundError(f"Image not found: {image_path}")
+    if not lattice_path.exists():
+        raise FileNotFoundError(f"Lattice file not found: {lattice_path}")
+
+    with lattice_path.open("r", encoding="utf-8") as handle:
+        lattice_data = json.load(handle)
+    if not isinstance(lattice_data, list):
+        lattice_data = [lattice_data]
+
+    regular_cols, regular_rows, shifted_cols, shifted_rows = _accumulate_boundaries(lattice_data)
+
+    image = Image.open(image_path).convert("RGBA")
+    width, height = image.size
+    draw = ImageDraw.Draw(image, "RGBA")
+
+    scale = max(int(args.latent_downsample), 1)
+
+    reg_cols_px = _to_pixels(regular_cols, scale, width)
+    reg_rows_px = _to_pixels(regular_rows, scale, height)
+    shift_cols_px = _to_pixels(shifted_cols, scale, width)
+    shift_rows_px = _to_pixels(shifted_rows, scale, height)
+
+    regular_color = (255, 0, 0, 160)
+    shifted_color = (0, 192, 255, 160)
+
+    for x in reg_cols_px:
+        draw.line((x, 0, x, height), fill=regular_color, width=2)
+    for y in reg_rows_px:
+        draw.line((0, y, width, y), fill=regular_color, width=2)
+
+    for x in shift_cols_px:
+        _draw_dashed_line(draw, (x, 0), (x, height), shifted_color, width=2)
+    for y in shift_rows_px:
+        _draw_dashed_line(draw, (0, y), (width, y), shifted_color, width=2)
+
+    save_path = Path(args.save) if args.save else image_path.with_name(f"{image_path.stem}_overlay.png")
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    image.convert("RGBA").save(save_path)
+    print(f"Overlay saved to: {save_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add CLI switches to record attention window metadata, emit lattice sidecars, and optionally invoke the overlay helper after saves【F:inference_cli.py†L216-L513】
- propagate the logging flag through runner/model construction and instrument NaSwinAttention blocks in both 7B and 3B stacks to expose cached lattice data with layer annotations【F:src/core/model_manager.py†L42-L175】【F:src/models/dit/nablocks/mmsr_block.py†L35-L333】【F:src/models/dit/nadit.py†L108-L191】【F:src/models/dit_v2/nablocks/attention/mmattn.py†L144-L246】【F:src/models/dit_v2/nablocks/mmsr_block.py†L30-L137】【F:src/models/dit_v2/nadit.py†L124-L220】
- add a standalone overlay utility to visualize regular and shifted window grids over generated images【F:tools/overlay_windows.py†L1-L178】

## Testing
- python -m compileall .【ffc2fa†L1-L101】

------
https://chatgpt.com/codex/tasks/task_e_68d131c5bc508325bab2aed1d4521b09